### PR TITLE
Add skill field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xlogin",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Universal login widget for Nostr and Solid",
   "main": "xlogin.js",
   "skill": "SKILL.md",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.2",
   "description": "Universal login widget for Nostr and Solid",
   "main": "xlogin.js",
+  "skill": "SKILL.md",
   "files": [
     "xlogin.js",
     "index.html",


### PR DESCRIPTION
## Summary
- Adds `"skill": "SKILL.md"` to `package.json` next to `"main"`
- Makes `SKILL.md` discoverable via the npm registry API response
- AI agents hitting `registry.npmjs.org/xlogin` will see the pointer immediately

Closes #1