### PR TITLE
Add solidweb.app to Solid provider list

### DIFF
--- a/xlogin.js
+++ b/xlogin.js
@@ -322,6 +322,7 @@
       { name: 'solidcommunity.net', url: 'https://solidcommunity.net' },
       { name: 'solidweb.me', url: 'https://solidweb.me' },
       { name: 'solidweb.org', url: 'https://solidweb.org' },
+      { name: 'solidweb.app', url: 'https://solidweb.app' },
       { name: 'solid.social', url: 'https://solid.social' }
     ]
     var solidBtns = solidProviders.map(function (p) {


### PR DESCRIPTION
## Summary
- Adds `https://solidweb.app` as a new Solid identity provider option in the login modal

Closes #6

## Test plan
- [ ] Open `index.html` in browser
- [ ] Click Login → Solid tab
- [ ] Verify `solidweb.app` button appears in the provider list