### PR TITLE
Fall back to pure-JS SHA-256 in non-secure contexts (#8)

### DIFF
--- a/xlogin.js
+++ b/xlogin.js
@@ -68,6 +68,19 @@
     _nip98AuthFetch = mod.authFetch
   })
 
+  // Pure-JS SHA-256 fallback for non-secure contexts (plain-HTTP LAN/IP),
+  // where window.crypto.subtle is undefined (#8). Loaded only when needed.
+  var _nobleSha256 = null
+  var _hashesReady = null
+  function loadHashesOnce() {
+    if (!_hashesReady) {
+      _hashesReady = import('https://esm.sh/@noble/hashes@1.4.0/sha256').then(function (mod) {
+        _nobleSha256 = mod.sha256
+      })
+    }
+    return _hashesReady
+  }
+
   // --- localStorage (Nostr accounts, compatible with nip07/Jumble) ---
   function loadAccounts() {
     try { return JSON.parse(localStorage.getItem('accounts')) || [] } catch (e) { return [] }
@@ -93,7 +106,16 @@
     return Array.from(bytes, function (b) { return b.toString(16).padStart(2, '0') }).join('')
   }
   async function sha256(msg) {
-    return new Uint8Array(await crypto.subtle.digest('SHA-256', msg))
+    // crypto.subtle is exposed only in secure contexts (HTTPS or
+    // localhost). On plain-HTTP LAN/IP origins (e.g.
+    // http://192.168.0.10:4443/) it is undefined, which would throw
+    // "Cannot read properties of undefined (reading 'digest')". Fall
+    // back to a pure-JS SHA-256 there. See #8.
+    if (globalThis.crypto && globalThis.crypto.subtle) {
+      return new Uint8Array(await crypto.subtle.digest('SHA-256', msg))
+    }
+    await loadHashesOnce()
+    return _nobleSha256(msg)
   }
 
   // --- NIP-01 ---

--- a/xlogin.js
+++ b/xlogin.js
@@ -75,6 +75,13 @@
   function loadHashesOnce() {
     if (!_hashesReady) {
       _hashesReady = import('https://esm.sh/@noble/hashes@1.4.0/sha256').then(function (mod) {
+        // Validate the import resolved to the shape we expect — if esm.sh
+        // ever changes how it re-exports @noble/hashes/sha256 we want a
+        // clear error from this Promise rejection rather than the opaque
+        // `TypeError: _nobleSha256 is not a function` later in sha256().
+        if (typeof mod.sha256 !== 'function') {
+          throw new Error('xlogin: @noble/hashes/sha256 import did not expose a `sha256` function (export shape changed)')
+        }
         _nobleSha256 = mod.sha256
       })
     }


### PR DESCRIPTION
Closes #8.

## Summary
- Feature-detect `crypto.subtle` and fall back to `@noble/hashes/sha256` when it's undefined.
- Native fast path (HTTPS / localhost) is unchanged — no extra fetch, no behavioral diff.
- Plain-HTTP LAN / IP origins (e.g. `http://192.168.0.10:4443/`) now sign Nostr events successfully instead of throwing `Cannot read properties of undefined (reading 'digest')`.
- @noble/hashes loaded via the same `esm.sh` dynamic-import pattern xlogin already uses for @noble/secp256k1. Lazy — only fetched on the first sign attempt in a non-secure context.

## Test plan
- [x] `node -c xlogin.js` — syntax valid.
- [ ] Manual: serve a page with `<script src="xlogin.js">` on `http://<lan-ip>:<port>/`. Sign a Nostr event. Was: digest error. Now: success.
- [ ] Manual: same flow at `http://localhost:<port>/` and `https://...` — unchanged behavior, no extra network request, no regression.

## Out of scope
NIP-04 AES-CBC paths at lines ~134–145 also use `crypto.subtle` (importKey / encrypt / decrypt). Same restriction, but only fires on encrypted DMs and is not exercised by the JSS auth flow that surfaced this bug. Worth a follow-up if encrypted-DM-over-LAN ever becomes a real use case.