### PR TITLE
Install secp256k1 sha256Sync, switch to schnorr.signSync (#10)

### DIFF
--- a/xlogin.js
+++ b/xlogin.js
@@ -54,8 +54,26 @@
   _ext = window.nostr || null
 
   // --- Dynamic imports ---
-  var _secpReady = import('https://esm.sh/@noble/secp256k1@1.7.1').then(function (mod) {
+  var _secpReady = import('https://esm.sh/@noble/secp256k1@1.7.1').then(async function (mod) {
     _secp = mod
+    // @noble/secp256k1@1.7.x's async sha256 always reaches into
+    // `crypto.subtle.digest`, which is undefined on non-secure
+    // contexts (plain-HTTP LAN/IP). Install a sync sha256 backed by
+    // @noble/hashes and route signing through `schnorr.signSync` so
+    // the async path (and crypto.subtle dependency) is never taken.
+    // See #10 for the call chain that surfaced this.
+    await loadHashesOnce()
+    _secp.utils.sha256Sync = function (...messages) {
+      var total = 0
+      for (var i = 0; i < messages.length; i++) total += messages[i].length
+      var buf = new Uint8Array(total)
+      var off = 0
+      for (var j = 0; j < messages.length; j++) {
+        buf.set(messages[j], off)
+        off += messages[j].length
+      }
+      return _nobleSha256(buf)
+    }
   })
 
   var _SolidSession = null
@@ -131,10 +149,14 @@
     return bytesToHex(await sha256(new TextEncoder().encode(ser)))
   }
   async function nostrSignEvent(event) {
+    // _secpReady installs `_secp.utils.sha256Sync`; signSync then
+    // never touches `crypto.subtle` and works on non-secure contexts
+    // (#10). Awaiting _secpReady guarantees the sync hash is set
+    // before signSync runs.
     await _secpReady
     var ev = Object.assign({}, event, { pubkey: _nostrPubKey })
     ev.id = await computeEventId(ev)
-    var sig = await _secp.schnorr.sign(ev.id, _nostrPrivKey)
+    var sig = _secp.schnorr.signSync(ev.id, _nostrPrivKey)
     ev.sig = bytesToHex(sig)
     return ev
   }


### PR DESCRIPTION
Closes #10.

## Summary
- After importing `@noble/secp256k1@1.7.1`, await the `@noble/hashes` loader (already added in #9) and install `_secp.utils.sha256Sync` backed by `nobleSha256`. Concatenates variadic messages per secp's contract.
- Switch `nostrSignEvent` from `await _secp.schnorr.sign(...)` to `_secp.schnorr.signSync(...)`. `signSync` uses `taggedHashSync` → our installed `sha256Sync` → `nobleSha256`. The async path (`taggedHash` → `A.sha256` → `b.web.subtle.digest`) is never taken.
- xlogin's own `sha256()` from #9 is unchanged — keeps the native fast path on HTTPS / localhost.

## Test plan
- [x] `node -c xlogin.js` syntax passes.
- [ ] Manual: serve a page on plain-HTTP LAN origin (e.g. `http://192.168.0.10:port/`). Sign in via Nostr key/guest, trigger a signing call (e.g. mashlib's sharing pane → `window.xlogin.authFetch` → `nip98.authFetch` → `window.nostr.signEvent` → `nostrSignEvent`). Was: `Cannot read properties of undefined (reading 'digest')`. Now: succeeds.
- [ ] Manual: same flow on `http://localhost:port/` and `https://...` — unchanged behaviour.

## Out of scope
NIP-04 AES-CBC paths at lines 150, 152, 158, 161 still use `crypto.subtle` directly. Same secure-context restriction, but only fires on encrypted DMs — not the JSS auth flow that surfaced this. Worth a follow-up if encrypted-DM-over-LAN ever becomes a real use case.