### PR TITLE
Add window.xlogin.ready Promise for restore-settled signal (#13)

### DIFF
--- a/xlogin.js
+++ b/xlogin.js
@@ -649,24 +649,29 @@
 
   // --- Init ---
   async function init() {
-    getUI()
+    // Wrap in try/finally so `window.xlogin.ready` always settles —
+    // any unexpected throw inside (beyond the known catches below)
+    // would otherwise leave consumers awaiting it forever (#14).
+    try {
+      getUI()
 
-    // 1. Solid redirect callback
-    var wasRedirect = await handleSolidRedirect().catch(function () { return false })
+      // 1. Solid redirect callback
+      var wasRedirect = await handleSolidRedirect().catch(function () { return false })
 
-    if (!wasRedirect) {
-      // 2. Try Nostr restore (await the async nip-07 tail too)
-      await tryNostrRestore()
+      if (!wasRedirect) {
+        // 2. Try Nostr restore (await the async nip-07 tail too)
+        await tryNostrRestore()
 
-      // 3. Try Solid restore if not already logged in via Nostr
-      if (!_type) {
-        await trySolidRestore().catch(function () {})
+        // 3. Try Solid restore if not already logged in via Nostr
+        if (!_type) {
+          await trySolidRestore().catch(function () {})
+        }
       }
+    } finally {
+      // Tell consumers (e.g., LOSOS shell) that restore has settled
+      // — success, no-session, or unexpected throw. See #13.
+      _readyResolve()
     }
-
-    // Tell consumers (e.g., LOSOS shell) that restore has settled
-    // — success or no-session. See #13.
-    _readyResolve()
   }
 
   if (document.readyState === 'loading') {

--- a/xlogin.js
+++ b/xlogin.js
@@ -571,18 +571,22 @@
   }
 
   // --- Nostr session restore ---
+  // Returns a Promise so the caller can await the async nip-07
+  // polling tail (#13). All other paths resolve synchronously.
   function tryNostrRestore() {
     var restored = loadCurrentAccount()
-    if (!restored) return
+    if (!restored) return Promise.resolve()
     if ((restored.signerType === 'key' || restored.signerType === 'guest') && restored.privkey) {
       _nostrPrivKey = restored.privkey
       _nostrPubKey = restored.pubkey
       _nostrProvider = restored.signerType
       var ui = getUI()
       if (ui && ui.btn) onLogin('nostr', restored.pubkey, ui.btn)
-    } else if (restored.signerType === 'nip-07') {
+      return Promise.resolve()
+    }
+    if (restored.signerType === 'nip-07') {
       _nostrPubKey = restored.pubkey
-      ;(async function () {
+      return (async function () {
         for (var i = 0; i < 50; i++) {
           if (_ext) {
             _nostrProvider = 'extension'
@@ -596,6 +600,7 @@
         saveCurrentAccount(null)
       })()
     }
+    return Promise.resolve()
   }
 
   function getUI() {
@@ -619,6 +624,11 @@
   window.xlogin.id = null
   window.xlogin.login = function () { showModal() }
   window.xlogin.logout = function () { onLogout(getUI().btn) }
+  // Resolves when init() has finished restoring (or settled on no
+  // session). Lets consumers `await window.xlogin.ready` instead of
+  // polling `window.xlogin.type` with a timeout. See #13.
+  var _readyResolve
+  window.xlogin.ready = new Promise(function (r) { _readyResolve = r })
 
   /**
    * Unified authenticated fetch.
@@ -645,14 +655,18 @@
     var wasRedirect = await handleSolidRedirect().catch(function () { return false })
 
     if (!wasRedirect) {
-      // 2. Try Nostr restore (synchronous / fast)
-      tryNostrRestore()
+      // 2. Try Nostr restore (await the async nip-07 tail too)
+      await tryNostrRestore()
 
       // 3. Try Solid restore if not already logged in via Nostr
       if (!_type) {
-        trySolidRestore().catch(function () {})
+        await trySolidRestore().catch(function () {})
       }
     }
+
+    // Tell consumers (e.g., LOSOS shell) that restore has settled
+    // — success or no-session. See #13.
+    _readyResolve()
   }
 
   if (document.readyState === 'loading') {


### PR DESCRIPTION
Closes #13.

## Summary
- Adds an additive `window.xlogin.ready: Promise<void>` that resolves once `init()` has finished restoring (or settled on no session).
- Lets consumers (LOSOS shell etc.) `await window.xlogin.ready` instead of polling `window.xlogin.type` with a timeout — no penalty for unauthenticated visitors.
- `tryNostrRestore` now returns a Promise so its async nip-07 tail is awaitable; sync paths return `Promise.resolve()`.
- `init()` awaits both restore functions and calls `_readyResolve()` at the end.

20 insertions, 6 deletions. No API removals.

## Test plan
- [x] `node -c xlogin.js` syntax passes.
- [ ] Manual: `await window.xlogin.ready` on a page with no saved account → resolves promptly (no 5s wait).
- [ ] Manual: `await window.xlogin.ready` after restoring a `key`/`guest` account → resolves with `window.xlogin.type === 'nostr'` set.
- [ ] Manual: `await window.xlogin.ready` after restoring a `nip-07` account where the extension is already present → resolves with `type === 'nostr'`.
- [ ] Manual: `await window.xlogin.ready` after restoring a `nip-07` account where the extension never appears → resolves within the existing 5s polling cap.

## Out of scope
- Re-checking `window.nostr` instead of the captured `_ext` in the nip-07 polling loop — separate bug, deserves its own issue.
- Unconditional `window.nostr` overwrite at IIFE start — same.