### PR TITLE
Phase 2a: show ?webid= SSO-arrival hint above the login button

### DIFF
--- a/xlogin.js
+++ b/xlogin.js
@@ -385,7 +385,7 @@
         hint.appendChild(idEl)
         shadow.appendChild(hint)
       }
-    } catch (_) { /* malformed URL — ignore */ }
+    } catch (_) { /* missing URLSearchParams or unexpected runtime — skip the hint, don't break login */ }
 
     // --- Overlay ---
     var overlay = document.createElement('div')

--- a/xlogin.js
+++ b/xlogin.js
@@ -304,6 +304,13 @@
   var CSS = [
     '.xl-btn{position:fixed;bottom:16px;right:16px;z-index:999999;background:#8B5CF6;color:#fff;border:none;border-radius:20px;padding:8px 16px;font:14px/1.4 system-ui,sans-serif;cursor:pointer;box-shadow:0 2px 8px rgba(0,0,0,.2);transition:background .2s}',
     '.xl-btn:hover{background:#7C3AED}',
+    // Phase 2a SSO-arrival hint: when a ?webid= URL param is present
+    // (typically set by jss.live/sso/ after resolving the user's
+    // identity), show the proposed identity as a small caption above
+    // the login button. PoC-only — purely informational at this
+    // stage, doesn't change click behavior.
+    '.xl-suggestion{position:fixed;bottom:60px;right:16px;z-index:999999;max-width:300px;background:#1a1a2e;color:#e0e0e0;border:1px solid #8B5CF6;border-radius:8px;padding:8px 12px;font:12px/1.4 system-ui,sans-serif;box-shadow:0 2px 8px rgba(0,0,0,.2);word-break:break-all}',
+    '.xl-suggestion strong{color:#8B5CF6}',
     '.xl-overlay{display:none;position:fixed;inset:0;z-index:1000000;background:rgba(0,0,0,.5);align-items:center;justify-content:center}',
     '.xl-overlay.active{display:flex}',
     '.xl-modal{background:#1a1a2e;color:#e0e0e0;border-radius:12px;padding:24px;width:380px;max-width:90vw;font:14px/1.4 system-ui,sans-serif;box-shadow:0 8px 32px rgba(0,0,0,.4)}',
@@ -357,6 +364,28 @@
       else showModal()
     }
     shadow.appendChild(btn)
+
+    // --- Phase 2a: SSO-arrival hint ---
+    // If a ?webid= query param is present (set by jss.live/sso/
+    // after resolving the user's Nostr identity), display it as
+    // a caption above the login button. Doesn't change click
+    // behavior — purely informational while we confirm the
+    // SSO → pod handoff works end-to-end. Phase 2b will use
+    // this to auto-trigger the appropriate login provider.
+    try {
+      var ssoWebId = new URLSearchParams(window.location.search).get('webid')
+      if (ssoWebId) {
+        var hint = document.createElement('div')
+        hint.className = 'xl-suggestion'
+        var label = document.createElement('div')
+        label.textContent = 'Sign in as:'
+        var idEl = document.createElement('strong')
+        idEl.textContent = ssoWebId
+        hint.appendChild(label)
+        hint.appendChild(idEl)
+        shadow.appendChild(hint)
+      }
+    } catch (_) { /* malformed URL — ignore */ }
 
     // --- Overlay ---
     var overlay = document.createElement('div')


### PR DESCRIPTION
Pairs with [JavaScriptSolidServer/sso#1](https://github.com/JavaScriptSolidServer/sso/issues/1) — the SSO page resolves a user's Nostr identity to a WebID and now redirects to their pod with `?webid=did:nostr:<pubkey>` appended.

This PR is **phase 2a only**: read the hint and *display* it above the existing Login button. Purely informational. Clicking the button still opens the normal modal. Goal: confirm the SSO → pod handoff wires up end-to-end before we add signing (phase 3) or auto-trigger (phase 2b).

## Before / after

**After** — pod page after SSO arrival at `https://test.solid.social/?webid=did:nostr:<pk>`:

```
  ┌──────────────────────────────┐
  │ Sign in as:                  │
  │ did:nostr:de7ecf…ebfe        │
  └──────────────────────────────┘
                    [Login]
```

No `?webid=` param → no caption, no behavior change.

## What changed

- `createWidget()`: after the button is appended, read `URLSearchParams(location.search).get('webid')`. If present, build a `<div class=\"xl-suggestion\">` with the value and append to the shadow root.
- CSS: new `.xl-suggestion` rule — small dark caption at `bottom:60px right:16px` (44px above the existing `.xl-btn`).
- Try/catch around `URLSearchParams` so a malformed URL silently skips the caption.

## Phases

- **2a** (this PR) — display the hint, don't act on it
- 2b — auto-trigger the matching provider (Nostr browser-extension flow) using the hint
- 2c — scrub the `?webid=` param from the URL after consumption
- 3 — replace trust-the-query-param with NIP-98 signed event in URL fragment