### PR TITLE
Phase 2b: auto-trigger Use Browser Extension on ?webid= arrival

### DIFF
--- a/xlogin.js
+++ b/xlogin.js
@@ -716,10 +716,25 @@
             if (hint) {
               var ui = getUI()
               if (ui && ui.btn) {
-                try {
-                  var pubkey = await _ext.getPublicKey()
+                // Fire-and-forget — do NOT await the signer prompt.
+                // The signer's getPublicKey() may block indefinitely
+                // while waiting for user approval (especially on
+                // extensions that show a popup), which would in turn
+                // delay window.xlogin.ready (the whole point of #14
+                // was to settle ready promptly regardless of pending
+                // user interaction). Consumers see ready resolve as
+                // "no session yet"; nostrLoginSuccess fires its own
+                // state-change event when/if the signer approves
+                // later, so async consumers still see the eventual
+                // login.
+                _ext.getPublicKey().then(function (pubkey) {
+                  // Mirror the manual extBtn.click() path: hide the
+                  // modal first so it doesn't stay open in the corner
+                  // case where the user opened it during the brief
+                  // auto-trigger window.
+                  hideModal()
                   nostrLoginSuccess(ui.btn, pubkey, 'extension')
-                } catch (_) { /* signer declined or unavailable — fall through to manual login */ }
+                }).catch(function () { /* signer declined or unavailable — fall through to manual login */ })
               }
             }
           } catch (_) { /* missing URLSearchParams or unexpected runtime — no-op */ }

--- a/xlogin.js
+++ b/xlogin.js
@@ -699,6 +699,31 @@
         if (!_type) {
           await trySolidRestore().catch(function () {})
         }
+
+        // 4. Phase 2b SSO-arrival auto-trigger. When a Solid app (e.g.
+        // jss.live/sso/) redirects the user to their pod with a
+        // ?webid= hint AND no prior session restored, AND a signer
+        // extension is present, automatically run the same
+        // getPublicKey() + nostrLoginSuccess() pair the
+        // "Use Browser Extension" button click runs. Saves the
+        // user a click; the signer extension is still in charge of
+        // approval (popup or pre-approved silent). The pubkey
+        // returned by the signer wins — the hint is a "should we
+        // try this" signal, not a credential.
+        if (!_type && _ext) {
+          try {
+            var hint = new URLSearchParams(window.location.search).get('webid')
+            if (hint) {
+              var ui = getUI()
+              if (ui && ui.btn) {
+                try {
+                  var pubkey = await _ext.getPublicKey()
+                  nostrLoginSuccess(ui.btn, pubkey, 'extension')
+                } catch (_) { /* signer declined or unavailable — fall through to manual login */ }
+              }
+            }
+          } catch (_) { /* missing URLSearchParams or unexpected runtime — no-op */ }
+        }
       }
     } finally {
       // Tell consumers (e.g., LOSOS shell) that restore has settled


### PR DESCRIPTION
Pairs with phase 2a ([#16](https://github.com/melvincarvalho/xlogin/pull/16), merged) and [JavaScriptSolidServer/sso#8](https://github.com/JavaScriptSolidServer/sso/issues/8) (the phased plan tracking issue).

Phase 2a rendered a caption when `?webid=` was present in the URL. This PR acts on it: if init() finishes the existing restore steps without a prior session **and** `?webid=` is present **and** a signer extension is available, automatically run the same `getPublicKey() + nostrLoginSuccess()` pair the "Use Browser Extension" button click runs. The user sees the signer popup (or a silent pre-approved sign) and is authenticated — no Login click needed.

## Behavior

|  | `?webid=` present | no `?webid=` |
|---|---|---|
| Prior session restored | no change (session wins) | no change |
| No session, ext available | **auto-trigger** (this PR) | no change |
| No session, no ext | caption only (2a) | no change |

## Trust model

The pubkey returned by the signer **wins**. We deliberately do NOT verify it matches the `?webid=` hint. The hint is a "should we try this" signal, not a credential. A future phase 3 will tighten with a NIP-98 signed event in the URL fragment.

## Failure mode

Signer rejects / unavailable → caught silently → user falls through to the existing manual login (caption from 2a still visible).

## Hook site

End of `init()` after the existing restore attempts, **before** the `finally` that resolves `_readyResolve`. So `window.xlogin.ready` still settles consistently whether 2b fires or not.

## Test plan

- [ ] Manual: `https://test.solid.social/?webid=did:nostr:<pk>` → signer prompt → authenticated (after publish + cache flip)
- [ ] Manual: same URL with the user already restored from a prior session → no signer prompt
- [ ] Manual: same URL with no extension installed → caption shown (2a), no auto-trigger, no error
- [ ] Manual: signer prompt declined → caption still visible, manual Login still works

## Refs

- [#16](https://github.com/melvincarvalho/xlogin/pull/16) — phase 2a (caption)
- [sso#8](https://github.com/JavaScriptSolidServer/sso/issues/8) — phased plan tracking issue