### PR TITLE
Phase 2c: scrub ?webid= and remove SSO-arrival popover (#19)

### DIFF
--- a/xlogin.js
+++ b/xlogin.js
@@ -304,13 +304,6 @@
   var CSS = [
     '.xl-btn{position:fixed;bottom:16px;right:16px;z-index:999999;background:#8B5CF6;color:#fff;border:none;border-radius:20px;padding:8px 16px;font:14px/1.4 system-ui,sans-serif;cursor:pointer;box-shadow:0 2px 8px rgba(0,0,0,.2);transition:background .2s}',
     '.xl-btn:hover{background:#7C3AED}',
-    // Phase 2a SSO-arrival hint: when a ?webid= URL param is present
-    // (typically set by jss.live/sso/ after resolving the user's
-    // identity), show the proposed identity as a small caption above
-    // the login button. PoC-only — purely informational at this
-    // stage, doesn't change click behavior.
-    '.xl-suggestion{position:fixed;bottom:60px;right:16px;z-index:999999;max-width:300px;background:#1a1a2e;color:#e0e0e0;border:1px solid #8B5CF6;border-radius:8px;padding:8px 12px;font:12px/1.4 system-ui,sans-serif;box-shadow:0 2px 8px rgba(0,0,0,.2);word-break:break-all}',
-    '.xl-suggestion strong{color:#8B5CF6}',
     '.xl-overlay{display:none;position:fixed;inset:0;z-index:1000000;background:rgba(0,0,0,.5);align-items:center;justify-content:center}',
     '.xl-overlay.active{display:flex}',
     '.xl-modal{background:#1a1a2e;color:#e0e0e0;border-radius:12px;padding:24px;width:380px;max-width:90vw;font:14px/1.4 system-ui,sans-serif;box-shadow:0 8px 32px rgba(0,0,0,.4)}',
@@ -364,28 +357,6 @@
       else showModal()
     }
     shadow.appendChild(btn)
-
-    // --- Phase 2a: SSO-arrival hint ---
-    // If a ?webid= query param is present (set by jss.live/sso/
-    // after resolving the user's Nostr identity), display it as
-    // a caption above the login button. Doesn't change click
-    // behavior — purely informational while we confirm the
-    // SSO → pod handoff works end-to-end. Phase 2b will use
-    // this to auto-trigger the appropriate login provider.
-    try {
-      var ssoWebId = new URLSearchParams(window.location.search).get('webid')
-      if (ssoWebId) {
-        var hint = document.createElement('div')
-        hint.className = 'xl-suggestion'
-        var label = document.createElement('div')
-        label.textContent = 'Sign in as:'
-        var idEl = document.createElement('strong')
-        idEl.textContent = ssoWebId
-        hint.appendChild(label)
-        hint.appendChild(idEl)
-        shadow.appendChild(hint)
-      }
-    } catch (_) { /* missing URLSearchParams or unexpected runtime — skip the hint, don't break login */ }
 
     // --- Overlay ---
     var overlay = document.createElement('div')
@@ -714,6 +685,15 @@
           try {
             var hint = new URLSearchParams(window.location.search).get('webid')
             if (hint) {
+              // Phase 2c: scrub `?webid=` now that we've consumed it.
+              // Keeps refresh / bookmark / share clean. Other query
+              // params (if any) are preserved.
+              try {
+                var clean = new URL(window.location.href)
+                clean.searchParams.delete('webid')
+                history.replaceState(null, '', clean.pathname + clean.search + clean.hash)
+              } catch (_) { /* history API unavailable — harmless, skip */ }
+
               var ui = getUI()
               if (ui && ui.btn) {
                 // Fire-and-forget — do NOT await the signer prompt.

--- a/xlogin.js
+++ b/xlogin.js
@@ -690,7 +690,7 @@
             try {
               var clean = new URL(window.location.href)
               clean.searchParams.delete('webid')
-              history.replaceState(null, '', clean.pathname + clean.search + clean.hash)
+              history.replaceState(null, '', clean.href)
             } catch (_) { /* history API unavailable — harmless, skip */ }
 
             // Phase 2b auto-trigger keeps its original guards.

--- a/xlogin.js
+++ b/xlogin.js
@@ -671,29 +671,30 @@
           await trySolidRestore().catch(function () {})
         }
 
-        // 4. Phase 2b SSO-arrival auto-trigger. When a Solid app (e.g.
-        // jss.live/sso/) redirects the user to their pod with a
-        // ?webid= hint AND no prior session restored, AND a signer
-        // extension is present, automatically run the same
-        // getPublicKey() + nostrLoginSuccess() pair the
-        // "Use Browser Extension" button click runs. Saves the
-        // user a click; the signer extension is still in charge of
-        // approval (popup or pre-approved silent). The pubkey
-        // returned by the signer wins — the hint is a "should we
-        // try this" signal, not a credential.
-        if (!_type && _ext) {
-          try {
-            var hint = new URLSearchParams(window.location.search).get('webid')
-            if (hint) {
-              // Phase 2c: scrub `?webid=` now that we've consumed it.
-              // Keeps refresh / bookmark / share clean. Other query
-              // params (if any) are preserved.
-              try {
-                var clean = new URL(window.location.href)
-                clean.searchParams.delete('webid')
-                history.replaceState(null, '', clean.pathname + clean.search + clean.hash)
-              } catch (_) { /* history API unavailable — harmless, skip */ }
+        // 4. SSO-arrival handling. When a Solid app (e.g. jss.live/sso/)
+        // redirects the user to their pod with a ?webid= hint, xlogin
+        // owns that param — clean it from the URL on sight (phase 2c),
+        // and if no prior session restored AND a signer extension is
+        // present, auto-run the same getPublicKey + nostrLoginSuccess
+        // pair the "Use Browser Extension" button click runs (phase
+        // 2b). Saves the user a click; the signer is still in charge
+        // of approval. The pubkey returned by the signer wins — the
+        // hint is a "should we try this" signal, not a credential.
+        try {
+          var hint = new URLSearchParams(window.location.search).get('webid')
+          if (hint) {
+            // Phase 2c: scrub `?webid=` whether or not we can act on
+            // it (session already restored, no extension, etc.).
+            // Keeps refresh / bookmark / share clean. Other query
+            // params (if any) are preserved.
+            try {
+              var clean = new URL(window.location.href)
+              clean.searchParams.delete('webid')
+              history.replaceState(null, '', clean.pathname + clean.search + clean.hash)
+            } catch (_) { /* history API unavailable — harmless, skip */ }
 
+            // Phase 2b auto-trigger keeps its original guards.
+            if (!_type && _ext) {
               var ui = getUI()
               if (ui && ui.btn) {
                 // Fire-and-forget — do NOT await the signer prompt.
@@ -717,8 +718,8 @@
                 }).catch(function () { /* signer declined or unavailable — fall through to manual login */ })
               }
             }
-          } catch (_) { /* missing URLSearchParams or unexpected runtime — no-op */ }
-        }
+          }
+        } catch (_) { /* missing URLSearchParams or unexpected runtime — no-op */ }
       }
     } finally {
       // Tell consumers (e.g., LOSOS shell) that restore has settled


### PR DESCRIPTION
Closes #19. Implements phase 2c from [sso#8](https://github.com/JavaScriptSolidServer/sso/issues/8) and rolls back the phase 2a popover.

## Summary

- **Scrub `?webid=` after consumption** — once the SSO-arrival auto-trigger reads the hint (xlogin.js:~685), call `history.replaceState` with the same URL minus that param. Keeps refresh / bookmark / share clean. Other query params, if any, are preserved.
- **Remove the phase 2a popover** — the SSO-arrival hint `<div class="xl-suggestion">` and its CSS. It was a diagnostic step to confirm the query-param handoff was visible end-to-end before #17 wired behavior to it. Now that 2b auto-triggers and the flow works, the popover is no longer load-bearing.
- **2b is unaffected** — the auto-trigger reads `?webid=` directly from `window.location.search`, not from the popover DOM. Removing the popover and scrubbing after the read leaves the auto-trigger logic untouched.

Net change: +9 / -29 lines.

## Test plan

- [ ] Hit `https://test.solid.social/?webid=did:nostr:<pk>` with extension installed
- [ ] Auto-trigger fires (current 2b behavior, unchanged)
- [ ] URL in address bar becomes `https://test.solid.social/` immediately
- [ ] No popover visible at any point during the flow
- [ ] Refresh the cleaned URL — no auto-trigger (no hint), no popover, manual login still works
- [ ] Direct visit without `?webid=` — nothing changes from prior behavior