### PR TITLE
Bump pinned solid-oidc 0.0.8 -> 0.0.9 (slash-tolerant issuer compare)

### DIFF
--- a/xlogin.js
+++ b/xlogin.js
@@ -77,7 +77,7 @@
   })
 
   var _SolidSession = null
-  var _solidReady = import('https://esm.sh/solid-oidc@0.0.8').then(function (mod) {
+  var _solidReady = import('https://esm.sh/solid-oidc@0.0.9').then(function (mod) {
     _SolidSession = mod.Session || mod.default
   })
 


### PR DESCRIPTION
## Summary
- Bumps the pinned Solid OIDC client at `xlogin.js:80` from `solid-oidc@0.0.8` to `@0.0.9`.
- 0.0.8's `handleRedirectFromLogin()` strict-compares the RFC 9207 `iss` param to the discovery issuer (`iss !== idp`). A trailing-slash-only difference throws before the token request; `init()`'s `.catch(() => false)` swallows it, so `POST /idp/token` never fires and the user is bounced back not-logged-in.
- 0.0.9 applies `trimSlash()` to both sides of that check (and the token-validation compare), so login succeeds regardless of the slash discrepancy.

Closes #22. Related server-side bug: JavaScriptSolidServer#524.

## Context
Surfaced running JavaScript Solid Server on Android (nodejs-mobile): the pod advertised the discovery `issuer` with a trailing slash but emitted `iss` without one. Worked around server-side by configuring the issuer with a slash; this is the general client-side fix so xlogin works against any IdP with that discrepancy.

## Test plan
- [ ] Normal desktop Solid login still works end-to-end (login -> consent -> token -> authFetch).
- [ ] Login against an IdP whose `iss` and discovery `issuer` differ by a trailing slash now completes.
- [ ] Nostr login path unaffected.