### PR TITLE
fix: resolve relative URLs in authFetch (closes #25)

### DIFF
--- a/xlogin.js
+++ b/xlogin.js
@@ -641,6 +641,11 @@
    * - Not logged in → plain fetch
    */
   window.xlogin.authFetch = async function (url, options) {
+    // Auth proofs bind to the absolute request URI (DPoP `htu`, NIP-98 `u`), and the underlying
+    // libs build it via `new URL(url)` — which, unlike fetch, does NOT default to the document
+    // base, so a relative string throws "Invalid URL". Resolve it the way fetch would, keeping
+    // authFetch a true drop-in for fetch (#25). A Request object is already absolute, so skip it.
+    if (typeof url === 'string') url = new URL(url, document.baseURI).href
     if (_type === 'nostr') {
       await _nip98Ready
       return _nip98AuthFetch(url, options)


### PR DESCRIPTION
## What

`authFetch` now resolves relative string URLs to absolute against `document.baseURI` before building the auth proof — making it a true drop-in for `fetch`.

Fixes #25.

## Why

DPoP (`htu`) and NIP-98 (`u`) bind the auth proof to the **absolute** request URI, and the underlying libs build it via `new URL(url)`, which — unlike `fetch` — does not default to the document base. So a relative string threw `TypeError: Failed to construct 'URL': Invalid URL`. Native `fetch` resolves relatives; `authFetch` didn't — a footgun given the documented `(window.xlogin && window.xlogin.authFetch) || fetch` pattern.

## Change

One guard at the top of `authFetch`:

```js
if (typeof url === 'string') url = new URL(url, document.baseURI).href
```

- Relative strings resolve exactly like `fetch`.
- Already-absolute strings pass through unchanged.
- A `Request` object skips the branch (its `.url` is already absolute).

Placed before the Nostr/Solid dispatch, so it covers both auth paths.

## Testing

- Resolution verified for relative, parent-relative (`../`), root-relative (`/`), and absolute inputs.
- `xlogin.js` parses.
- The full DPoP round-trip was exercised via the Melvo Predicts (worldcup) match editor that originally hit this bug.

## Follow-up

- Needs a patch version bump + `npm publish` for unpkg consumers to pick it up.
- The call-site workaround in melvo-predicts (`new URL('data/results.json', location.href)`) can be removed once this is published.