### PR TITLE
feat: window.xlogin.guestLogin(privkey) — modal-less login for key-in-a-link onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,9 @@ window.xlogin.id     // pubkey (nostr) or webId (solid)
 const res = await window.xlogin.authFetch('https://example.com/api/data')
 
 // Programmatic
-window.xlogin.login()   // open modal
-window.xlogin.logout()  // log out
+window.xlogin.login()            // open modal
+window.xlogin.logout()           // log out
+await window.xlogin.guestLogin(privkey)  // log in with a 64-hex Nostr key, no modal (key-in-a-link)
 ```
 
 ### Nostr (NIP-07 compatible)

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ window.xlogin.logout()           // log out
 await window.xlogin.guestLogin(privkey)  // log in with a 64-hex Nostr key, no modal (key-in-a-link)
 ```
 
+> ⚠️ **`guestLogin` persists the private key to localStorage.** A key carried in a link is a **bearer credential** — anyone with the link controls the account. Put it in the URL **#fragment** (never sent to the server) and use it only for low-stakes / onboarding keys.
+
 ### Nostr (NIP-07 compatible)
 
 After Nostr login, `window.nostr` is fully functional:

--- a/SKILL.md
+++ b/SKILL.md
@@ -41,7 +41,7 @@ npm install xlogin
 | `window.xlogin.id` | pubkey (nostr) or webId (solid) or `null` |
 | `window.xlogin.login()` | Open the login modal |
 | `window.xlogin.logout()` | Log out and clear session |
-| `window.xlogin.guestLogin(privkey)` | Log in directly with a 64-hex Nostr key, no modal (for key-in-a-link onboarding); persists as a guest session. Returns the pubkey. |
+| `window.xlogin.guestLogin(privkey)` | Log in directly with a 64-hex Nostr key, no modal (for key-in-a-link onboarding); persists as a guest session. Returns the pubkey. **⚠️ Stores the key in localStorage; a key in a link is a bearer credential — use the URL #fragment, low-stakes only.** |
 | `window.xlogin.authFetch(url, options)` | Authenticated fetch (NIP-98 for Nostr, DPoP for Solid, plain fetch if not logged in) |
 
 ### Protocol-Specific Globals

--- a/SKILL.md
+++ b/SKILL.md
@@ -41,6 +41,7 @@ npm install xlogin
 | `window.xlogin.id` | pubkey (nostr) or webId (solid) or `null` |
 | `window.xlogin.login()` | Open the login modal |
 | `window.xlogin.logout()` | Log out and clear session |
+| `window.xlogin.guestLogin(privkey)` | Log in directly with a 64-hex Nostr key, no modal (for key-in-a-link onboarding); persists as a guest session. Returns the pubkey. |
 | `window.xlogin.authFetch(url, options)` | Authenticated fetch (NIP-98 for Nostr, DPoP for Solid, plain fetch if not logged in) |
 
 ### Protocol-Specific Globals

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xlogin",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "Universal login widget for Nostr and Solid",
   "main": "xlogin.js",
   "skill": "SKILL.md",

--- a/xlogin.js
+++ b/xlogin.js
@@ -631,8 +631,11 @@
   // Log in directly with a Nostr private key (64-hex) — no modal. For "key in a link"
   // onboarding: read the key from the URL and call this. Persists as a guest session
   // (localStorage), identical to the modal's "Continue as Guest". Returns the pubkey.
+  // SECURITY: the key is stored in localStorage; in the link pattern it is a BEARER
+  // credential (anyone with the link IS the account). Use the URL #fragment so it never
+  // reaches the server, and only for low-stakes / onboarding keys.
   window.xlogin.guestLogin = async function (privkey) {
-    privkey = (privkey || '').trim().toLowerCase()
+    privkey = String(privkey || '').trim().toLowerCase()
     if (!/^[0-9a-f]{64}$/.test(privkey)) throw new Error('guestLogin: 64-hex private key required')
     await _secpReady
     var ui = getUI()

--- a/xlogin.js
+++ b/xlogin.js
@@ -628,6 +628,18 @@
   window.xlogin.id = null
   window.xlogin.login = function () { showModal() }
   window.xlogin.logout = function () { onLogout(getUI().btn) }
+  // Log in directly with a Nostr private key (64-hex) — no modal. For "key in a link"
+  // onboarding: read the key from the URL and call this. Persists as a guest session
+  // (localStorage), identical to the modal's "Continue as Guest". Returns the pubkey.
+  window.xlogin.guestLogin = async function (privkey) {
+    privkey = (privkey || '').trim().toLowerCase()
+    if (!/^[0-9a-f]{64}$/.test(privkey)) throw new Error('guestLogin: 64-hex private key required')
+    await _secpReady
+    _nostrPrivKey = privkey
+    var pubkey = bytesToHex(_secp.schnorr.getPublicKey(privkey))
+    nostrLoginSuccess(getUI().btn, pubkey, 'guest')
+    return pubkey
+  }
   // Resolves when init() has finished restoring (or settled on no
   // session). Lets consumers `await window.xlogin.ready` instead of
   // polling `window.xlogin.type` with a timeout. See #13.

--- a/xlogin.js
+++ b/xlogin.js
@@ -635,9 +635,12 @@
     privkey = (privkey || '').trim().toLowerCase()
     if (!/^[0-9a-f]{64}$/.test(privkey)) throw new Error('guestLogin: 64-hex private key required')
     await _secpReady
+    var ui = getUI()
+    var btn = ui && ui.btn                       // getUI() is null before document.body; onLogin/onLogout guard btn
+    if (_type) onLogout(btn)                      // clear any existing session first (avoid mixed Nostr/Solid state)
     _nostrPrivKey = privkey
     var pubkey = bytesToHex(_secp.schnorr.getPublicKey(privkey))
-    nostrLoginSuccess(getUI().btn, pubkey, 'guest')
+    nostrLoginSuccess(btn, pubkey, 'guest')
     return pubkey
   }
   // Resolves when init() has finished restoring (or settled on no

--- a/xlogin.js
+++ b/xlogin.js
@@ -640,6 +640,7 @@
     if (_type) onLogout(btn)                      // clear any existing session first (avoid mixed Nostr/Solid state)
     _nostrPrivKey = privkey
     var pubkey = bytesToHex(_secp.schnorr.getPublicKey(privkey))
+    hideModal()                                  // close the modal if it happens to be open (matches guest/key flows)
     nostrLoginSuccess(btn, pubkey, 'guest')
     return pubkey
   }


### PR DESCRIPTION
## What

Adds `window.xlogin.guestLogin(privkey)` — log in directly with a 64-hex Nostr private key, **no modal**. Persists as a guest session in localStorage (identical to the modal's "Continue as Guest"), so it auto-restores on return visits. Returns the pubkey.

```js
const pubkey = await window.xlogin.guestLogin(keyFromHash);
```

## Why

Enables **one-tap "key in a link" onboarding**: an invite link carries a Nostr key in the URL fragment, the page reads it and calls `guestLogin()`, and the user is in — no button, no modal, no concepts. Today a `data-guest` key only becomes a session via the modal's "Continue as Guest" button; there was no programmatic path.

## Implementation

Exposes the exact logic the Guest button already runs, as a public method:

```js
window.xlogin.guestLogin = async function (privkey) {
  privkey = (privkey || '').trim().toLowerCase()
  if (!/^[0-9a-f]{64}$/.test(privkey)) throw new Error('guestLogin: 64-hex private key required')
  await _secpReady
  _nostrPrivKey = privkey
  var pubkey = bytesToHex(_secp.schnorr.getPublicKey(privkey))
  nostrLoginSuccess(getUI().btn, pubkey, 'guest')
  return pubkey
}
```

Non-breaking (new method only). Docs added to README + SKILL.md. Version bumped to `0.0.15`.

## Note

A key in a no-server link is a **bearer credential** — fine for low-stakes / testnet / friends onboarding (and the link doubles as account backup), not for high-value accounts. Use the URL **fragment** (`#…`) so the key never reaches the server.